### PR TITLE
Synth fix in obi_to_axi.sv

### DIFF
--- a/future/axi_obi/src/obi_to_axi.sv
+++ b/future/axi_obi/src/obi_to_axi.sv
@@ -175,13 +175,11 @@ module obi_to_axi #(
     end
   end
 
-  generate
-    if (AxiDataWidth > ObiCfg.DataWidth) begin
-      assign data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
-    end else begin
-      assign data_offset = '0;
-    end
-  endgenerate
+  if (AxiDataWidth > ObiCfg.DataWidth) begin : gen_data_offset
+    assign data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
+  end else begin : gen_no_data_offset
+    assign data_offset = '0;
+  end
 
   // Control for translating request to the AXI4-Lite `AW`, `W` and `AR` channels.
   always_comb begin : proc_request_control

--- a/future/axi_obi/src/obi_to_axi.sv
+++ b/future/axi_obi/src/obi_to_axi.sv
@@ -175,12 +175,17 @@ module obi_to_axi #(
     end
   end
 
+  generate
+    if (AxiDataWidth > ObiCfg.DataWidth) begin
+      assign data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
+    end else begin
+      assign data_offset = '0;
+    end
+  endgenerate
+
   // Control for translating request to the AXI4-Lite `AW`, `W` and `AR` channels.
   always_comb begin : proc_request_control
-    data_offset = '0;
-    if (AxiDataWidth > ObiCfg.DataWidth) begin
-      data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
-    end
+  
     axi_req_o.aw_valid = 1'b0;
     axi_req_o.w_valid  = 1'b0;
     axi_req_o.ar_valid = 1'b0;


### PR DESCRIPTION
```
data_offset = '0;
if (AxiDataWidth > ObiCfg.DataWidth) begin
    data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
end
```
This code in the always_comb was causing issue with Synopsys DC because even if the condition is not true the compiler tries to access to undefined variable.
The fix is made using a generate block.
```
generate
    if (AxiDataWidth > ObiCfg.DataWidth) begin
        assign data_offset = obi_req_i.a.addr[$clog2(ObiCfg.DataWidth/8)+:$clog2(AxiDataWidth/ObiCfg.DataWidth)];
    end else begin
        assign data_offset = '0;
    end
endgenerate
```